### PR TITLE
Add support for Prosemirror italic marks

### DIFF
--- a/lib/storyblok/richtext/html_renderer/marks/italic.rb
+++ b/lib/storyblok/richtext/html_renderer/marks/italic.rb
@@ -3,7 +3,7 @@ module Storyblok::Richtext
     class Italic < Mark
 
       def matching
-        @node['type'] === 'italic'
+        @node['type'] == 'italic' || @node['type'] == 'i' || @node['type'] == 'em'
       end
 
       def tag

--- a/lib/storyblok/richtext/html_renderer/marks/italic.rb
+++ b/lib/storyblok/richtext/html_renderer/marks/italic.rb
@@ -3,7 +3,7 @@ module Storyblok::Richtext
     class Italic < Mark
 
       def matching
-        @node['type'] == 'italic' || @node['type'] == 'i' || @node['type'] == 'em'
+        ['italic', 'i', 'em'].include?(@node['type'])
       end
 
       def tag

--- a/spec/richtext_spec.rb
+++ b/spec/richtext_spec.rb
@@ -17,12 +17,40 @@ describe 'richtext' do
                 'class' => 'red'
               }
             }
+          ],
+        },
+        {
+          'type' => 'paragraph',
+          'content' => [
+            {
+              'type' => 'text',
+              'marks' => [
+                {
+                  'type' => 'i'
+                }
+              ],
+              'text' => 'Italic'
+            }
+          ]
+        },
+        {
+          'type' => 'paragraph',
+          'content' => [
+            {
+              'type' => 'text',
+              'marks' => [
+                {
+                  'type' => 'em'
+                }
+              ],
+              'text' => 'Italic too'
+            }
           ]
         }
       ]
     }
 
     renderer = Storyblok::Richtext::HtmlRenderer.new
-    expect(renderer.render(doc)).to eq('<span class="red">red text</span>')
+    expect(renderer.render(doc)).to eq('<span class="red">red text</span><p><i>Italic</i></p><p><i>Italic too</i></p>')
   end
 end


### PR DESCRIPTION
Prosemirror uses [`em`](https://github.com/ProseMirror/prosemirror-schema-basic/blob/669e5d01bf1f9259bc511e4af58b5d56ecad15a6/src/schema-basic.js#L125-L130) but can also handle `i`. `italic` seems to be something storyblok specific maybe?