### PR TITLE
Hotfix/add href with mailto

### DIFF
--- a/lib/storyblok/richtext/html_renderer/marks/link.rb
+++ b/lib/storyblok/richtext/html_renderer/marks/link.rb
@@ -11,11 +11,17 @@ module Storyblok::Richtext
 
         if attrs['anchor'].is_a?(String) and !attrs['anchor'].empty?
           attrs['href'] = "#{attrs['href']}##{attrs['anchor']}"
+          attrs.delete('anchor')
+        end
+
+        if attrs['linktype'].is_a?(String) and attrs['linktype'] == 'email'
+          emailContainer = attrs['href']
+          attrs['href'] = "mailto:#{emailContainer}"
         end
 
         [{
           tag: "a",
-          attrs: attrs.slice('href', 'target')
+          attrs: attrs
         }]
       end
     end

--- a/spec/richtext_spec.rb
+++ b/spec/richtext_spec.rb
@@ -129,7 +129,7 @@ describe 'richtext' do
     }
 
     renderer = Storyblok::Richtext::HtmlRenderer.new
-    expect(renderer.render(doc)).to eq('<a href="/link" target="_blank">link text</a>')
+    expect(renderer.render(doc)).to eq('<a href="/link" target="_blank" uuid="300aeadc-c82d-4529-9484-f3f8f09cf9f5">link text</a>')
   end
 end
 
@@ -178,6 +178,34 @@ describe 'richtext' do
     }
 
     renderer = Storyblok::Richtext::HtmlRenderer.new
-    expect(renderer.render(doc)).to eq('<a href="/link#anchor-text" target="_blank">link text</a>')
+    expect(renderer.render(doc)).to eq('<a href="/link#anchor-text" target="_blank" uuid="300aeadc-c82d-4529-9484-f3f8f09cf9f5">link text</a>')
+  end
+end
+
+describe 'richtext' do
+  it 'link to generate a tag with an email' do
+    doc = {
+      'type' => 'doc',
+      'content' => [
+      {
+        'text' => 'an email link',
+        'type' => 'text',
+        'marks' => [
+          {
+            'type' => 'link',
+            'attrs' => {
+              'href' => 'email@client.com',
+              'target' => '_blank',
+              'uuid' => nil,
+              'linktype' => 'email'
+            }
+          }
+        ]
+      }
+    ]
+    }
+
+    renderer = Storyblok::Richtext::HtmlRenderer.new
+    expect(renderer.render(doc)).to eq('<a href="mailto:email@client.com" target="_blank" linktype="email">an email link</a>')
   end
 end


### PR DESCRIPTION
In this PR I add verification of `mailto:` in `href`, and refactor code to generate `<a/>` tags.